### PR TITLE
Apply target for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,9 +1434,9 @@
       }
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/chai-http": "^3.0.5",
     "@types/mocha": "^5.2.5",
     "tslint": "^5.18.0",
-    "typescript": "^3.0.1"
+    "typescript": "^3.2.2"
   },
   "dependencies": {
     "@types/express": "^4.16.0",


### PR DESCRIPTION
Apply target `typescript-version::typescript-version`:

**TypeScript version**
_TypeScript version_ > ```^3.2.2```

---
<details>
<summary>Commands</summary>
<br/>

You can trigger Atomist commands by commenting on this PR:
- `@atomist opt out` will stop raising automatic target PRs for this repository
- `@atomist help` start your comment with this to ask Atomist for help or provide feedback

[Link this repository to a Slack channel](https://app.atomist.com/workspace/A2MO4H2RG/settings/integrations/slack?repo=ipcrmdemo%2Fnov6node) to manage these updates directly from Slack.

</details>

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=e16df29f214762c43c105ac4addd1919a495aea9801e2765a28ae08c4d58e489]</code>
</details>